### PR TITLE
Ensure history doesn't become unreadable when an invalid card is read

### DIFF
--- a/assets/read.js
+++ b/assets/read.js
@@ -918,7 +918,7 @@
         var detail = {};
         _transceive = getWrappedTransceive(apdu_history, tag.type);
         try {
-            var { card_type, ..._detail } = await ReadAnyCard(tag);
+            let { card_type, ..._detail } = await ReadAnyCard(tag);
             Object.assign(detail, _detail);
             // pass ndef struct to detail
             detail["ndef"] = tag["ndef"];


### PR DESCRIPTION
Hi! This minor fix avoids all history disappearing from the app when an "invalid" card (one for which card_type is undefined) is encountered.

(I've had to make a few minor changes to get things to compile on my machine at all, but those seem unrelated).