### PR TITLE
utilities.dart: Check if sub_cards exists before accessing its length

### DIFF
--- a/lib/utilities.dart
+++ b/lib/utilities.dart
@@ -172,7 +172,7 @@ List<Detail> parseCardDetails(Map<String, dynamic> data, BuildContext context) {
   }
 
   // card number(s)
-  if (d['sub_cards'].length > 1) {
+  if (d.containsKey('sub_cards') && d['sub_cards'].length > 1) {
     for (var c in d['sub_cards']) {
       final cardType = getEnumFromString<CardType>(CardType.values, c['card_type'] ?? '');
       details.add(Detail(


### PR DESCRIPTION
Data of v2.4.0 does not have sub_cards in its card data. In such situation if user upgrade the app to version with multi-card support without cleaning its old data, a red error page will show up instead of card data. And the only way for user to continue to use nfsee would be clean all existing data, which is not good.

With this patch, we check if the sub_cards exists before trying to display card info. As a result, users can have a better upgrade experience.